### PR TITLE
Dynamic partials with lookup is broken

### DIFF
--- a/test.js
+++ b/test.js
@@ -86,6 +86,20 @@ describe('assemble-handlebars-helpers', function() {
         cb();
       });
     });
+
+    it('should render dynamic partials using {{lookup}} helper', function(cb) {
+      app.page('b.hbs', { content: '{{> (lookup data "partial") partialData }}'});
+      app.partial('partial.hbs', { content: '{{answer}}'});
+      var context = {
+        data: { partial: 'partial' },
+        partialData: { answer: '42' }
+      };
+      app.render('b.hbs', context, function(err, results) {
+        if (err) return cb(err);
+        assert.equal(results.content, '42');
+        cb();
+      });
+    });
   });
 
   describe('unless', function() {


### PR DESCRIPTION
Handlebars try to render partial with the name asyncid instead of requested dynamic lookup one.
`1) assemble-handlebars-helpers lookup should render dynamic partials using {{lookup}} helper:
     Error: The partial {$ASYNCID$19$0$} could not be found
      at Object.invokePartial (node_modules/handlebars/dist/cjs/handlebars/runtime.js:266:11)
      at Object.invokePartialWrapper [as invokePartial] (node_modules/handlebars/dist/cjs/handlebars/runtime.js:68:39)
      at Object.eval (eval at createFunctionContext (node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js:254:23), <anonymous>:5:31)
`
